### PR TITLE
Add support for activated and deactivated hooks

### DIFF
--- a/src/js/components/Splide.vue
+++ b/src/js/components/Splide.vue
@@ -57,6 +57,16 @@
     beforeDestroy() {
 			this.splide.destroy();
     },
+		
+		activated() {
+			this.splide = new Splide( this.$el, this.options );
+			this.bind();
+	    this.splide.mount( this.extensions, this.transition );
+    },
+
+    desactivated() {
+    	this.splide.destroy();
+    },
 
 	  watch: {
 		  /**


### PR DESCRIPTION
Activated and deactivated hooks are fired instead of mounted and beforeDestroy when using <keep-alive>.
This is needed if we would like to change to options of the splide (changing options.start to keep previously seen index for example)