### PR TITLE
Bind events before mount on remount

### DIFF
--- a/src/js/components/Splide.vue
+++ b/src/js/components/Splide.vue
@@ -121,8 +121,8 @@
 		  remount() {
       	this.$nextTick( () => {
 		      this.splide.destroy();
-		      this.splide.mount();
 		      this.bind();
+		      this.splide.mount();
         } );
       },
 	  },


### PR DESCRIPTION
Right now, on `remount()`, the events are only bound after the `splide.mount()`, meaning that the **mounted** event is not emitted by the Splide component.

This pull request fixes it by binding the events after the `splide.destroy()` but before `splide.mount()`.