### PR TITLE
use beforeUnmount

### DIFF
--- a/src/js/components/Splide.vue
+++ b/src/js/components/Splide.vue
@@ -54,7 +54,7 @@
 	    this.splide.mount( this.extensions, this.transition );
     },
 
-    beforeDestroy() {
+    beforeUnmount() {
 			this.splide.destroy();
     },
 


### PR DESCRIPTION
Vue 3 displays a warning when using `beforeDestroy`:
```[Vue warn]: `beforeDestroy` has been renamed to `beforeUnmount`. ```
This PR uses `beforeUnmount` instead.