### PR TITLE
Update index.js

### DIFF
--- a/src/js/index.js
+++ b/src/js/index.js
@@ -5,8 +5,8 @@
  * @copyright Naotoshi Fujita. All rights reserved.
  */
 
-import Splide from './components/Splide';
-import SplideSlide from './components/SplideSlide';
+import Splide from './components/Splide.vue';
+import SplideSlide from './components/SplideSlide.vue';
 
 export default {
 	install( Vue, options ) {


### PR DESCRIPTION
Please see https://github.com/vuejs/vue-cli/issues/5549#issuecomment-638850440 - VUE-CLI no longer supports extension-less imports of SPC's (Single Page Components) - which is now breaking the vue-splide plugin :-(