### PR TITLE
improve emit types for Splide component

### DIFF
--- a/src/js/components/Splide/Splide.vue
+++ b/src/js/components/Splide/Splide.vue
@@ -24,7 +24,7 @@ import SplideTrack from '../SplideTrack/SplideTrack.vue';
  */
 export default defineComponent( {
   name: 'Splide',
-  emits: EVENTS.map( event => `splide:${ event }` ),
+  emits: EVENTS.map<`splide:${typeof EVENTS[number]}`>( event => `splide:${ event }` ),
   components: { SplideTrack },
 
   props: {


### PR DESCRIPTION
<!--
  Please make sure to add a new issue before you send PR!
-->

## Related Issues

<!--
  Link to the issue
-->

didn't add an issue, because there is only a template for a bug, this pr is for improvement

## Description

<!-- Write a brief description here -->
at the moment typescript cannot hint Splide component's `emits` because it is of type `string[]`

in other words this pr turns this 

<img width="507" alt="image" src="https://user-images.githubusercontent.com/29009741/163721080-7604ed63-763e-46d1-8c56-3db2c29c1f6d.png">

into this
<img width="504" alt="image" src="https://user-images.githubusercontent.com/29009741/163721059-8c13e7e1-68c3-4759-bb65-f3dbc922bbf2.png">
