### PR TITLE
fix: TS2339 on value.slice()

### DIFF
--- a/src/js/utils/merge/merge.ts
+++ b/src/js/utils/merge/merge.ts
@@ -36,7 +36,7 @@ export function merge<T extends object, U extends object>( object: T, source: U 
 
   forOwn( source, ( value, key ) => {
     if ( Array.isArray( value ) ) {
-      merged[ key ] = value.slice();
+      merged[ key ] = (value as []).slice();
     } else if ( isObject( value ) ) {
       merged[ key ] = merge( isObject( merged[ key ] ) ? merged[ key ] : {}, value );
     } else {


### PR DESCRIPTION
## Related Issues
https://github.com/Splidejs/splide/issues/1215

## Description
Adding a simple type hint prevents TypeScript from complaining about `value.slice()`.