### PR TITLE
Allow setting a destroy delay

### DIFF
--- a/dist/js/vue-splide.cjs.js
+++ b/dist/js/vue-splide.cjs.js
@@ -2689,8 +2689,10 @@ const _sfc_main$1 = vue.defineComponent({
       }
     });
     vue.onBeforeUnmount(() => {
-      var _a;
-      (_a = splide.value) == null ? void 0 : _a.destroy();
+      setTimeout(() => {
+        var _a;
+        (_a = splide.value) == null ? void 0 : _a.destroy();
+      }, props.options.destroyDelay || 0);
     });
     vue.watch(() => merge({}, props.options), (options) => {
       if (splide.value) {

--- a/dist/js/vue-splide.esm.js
+++ b/dist/js/vue-splide.esm.js
@@ -2687,8 +2687,10 @@ const _sfc_main$1 = defineComponent({
       }
     });
     onBeforeUnmount(() => {
-      var _a;
-      (_a = splide.value) == null ? void 0 : _a.destroy();
+      setTimeout(() => {
+        var _a;
+        (_a = splide.value) == null ? void 0 : _a.destroy();
+      }, props.options.destroyDelay || 0);
     });
     watch(() => merge({}, props.options), (options) => {
       if (splide.value) {

--- a/src/js/components/Splide/Splide.vue
+++ b/src/js/components/Splide/Splide.vue
@@ -76,7 +76,9 @@ export default defineComponent( {
     } );
 
     onBeforeUnmount( () => {
-      splide.value?.destroy();
+      setTimeout(() => {
+        splide.value?.destroy();
+      }, props.options.destroyDelay || 0);
     } );
 
     watch( () => merge( {}, props.options ), options => {


### PR DESCRIPTION
## Related Issues

Fixes https://github.com/Splidejs/vue-splide/issues/80

## Description

Destroying a carousel can appear as a visual bug in certain situations, due to transitions and the like. By providing an ability to delay the carousel destroy, users can wait for whatever is interfering to finish its work and then destroy the carousel.
