### PR TITLE
Fix for #94 (TS5 compile error)

### DIFF
--- a/src/js/utils/merge/merge.ts
+++ b/src/js/utils/merge/merge.ts
@@ -36,7 +36,7 @@ export function merge<T extends object, U extends object>( object: T, source: U 
 
   forOwn( source, ( value, key ) => {
     if ( Array.isArray( value ) ) {
-      merged[ key ] = value.slice();
+      merged[ key ] = (value as []).slice();
     } else if ( isObject( value ) ) {
       merged[ key ] = merge( isObject( merged[ key ] ) ? merged[ key ] : {}, value );
     } else {


### PR DESCRIPTION
## Related Issues

Fixes #94

## Description

variable `value` is of type `object` (`U[keyof U]` and type U is `U extends object`) which means that splice does not exist on that. This commit fixes this.
