### PR TITLE
Fix strict TypeScript errors

### DIFF
--- a/src/js/plugin/plugin.ts
+++ b/src/js/plugin/plugin.ts
@@ -4,7 +4,7 @@ import { Splide, SplideSlide } from '../components';
 
 export const VueSplide = {
   install( app: App ): void {
-    app.component( Splide.name, Splide );
-    app.component( SplideSlide.name, SplideSlide );
+    app.component( Splide.name!, Splide );
+    app.component( SplideSlide.name!, SplideSlide );
   },
 };


### PR DESCRIPTION
`app.component` only allows `string` as a first parameter: https://github.com/vuejs/core/blob/422ef34e487f801e1162bed80c0e88e868576e1d/packages/runtime-core/src/apiCreateApp.ts#L44

But `Splide.name` and `SplideSlide.name` are typed as `string | undefined`: https://github.com/vuejs/core/blob/422ef34e487f801e1162bed80c0e88e868576e1d/packages/runtime-core/src/componentOptions.ts#L131

So to pass [`strict`](https://www.typescriptlang.org/docs/handbook/2/basic-types.html#strictness) TypeScript type-checking, a [non-null assertion operator](https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#non-null-assertion-operator-postfix-) can manually declare that the names are indeed non-nullable (see e.g. [`a3657c7`/src/js/components/Splide/Splide.vue#L26](https://togithub.com/Splidejs/vue-splide/blob/a3657c7b63aa851ea163bde5774e3e776f504f4e/src/js/components/Splide/Splide.vue#L26)).